### PR TITLE
minuscule edits 

### DIFF
--- a/text_formalization/README
+++ b/text_formalization/README
@@ -14,7 +14,7 @@ X- general/  general definitions and tactics.
    See general/audit_formal_proof.hl for a summary of files references in the 
    publication "A Formal Proof of the Kepler Conjecture"
    See general/the_kepler_conjecture.hl for the proved kepler conjecture.
-   See general/the_main_stament.hl for the reduced form of the main statement that avoids
+   See general/the_main_statement.hl for the reduced form of the main statement that avoids
      the linear programming and nonlinear inequality parts of the proof.
 X- nonlinear/  a list of nonlinear inequalities that are used in the text part of the proof
     See nonlinear/mk_all_ineq.hl for the code that generates the theorem

--- a/text_formalization/build/build.hl
+++ b/text_formalization/build/build.hl
@@ -16,7 +16,7 @@
   build/strictbuild.hl should be used to load the files here.
 
    Make sure the reference load_path points to the
-   flyspeck/text_formalization dir If the "FLYSPECK_DIR" environment
+   flyspeck/text_formalization dir. If the "FLYSPECK_DIR" environment
    variable is set to this directory then this can be done with
 
    let add_to_load_path path =


### PR DESCRIPTION
I made two minuscule edits while browsing the project. 

1. In a README, replace 'stament' with 'statement'. 

2. In a build file, add a '.' at the end of a sentence in a comment. 